### PR TITLE
fix(resource_organization): ensure Read repopulates organization ID in state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.6] - 2025-07-03
+### Fixed
+- Fixed a bug where the `awsworkmail_organization` resource did not repopulate the `id` attribute in state after a refresh. The Read method now looks up the organization by alias and ensures the ID is always set, improving compatibility with outputs and dependent resources.
+
 ## [Unreleased]
 - Work in progress
 


### PR DESCRIPTION
- Implemented a proper Read method for the awsworkmail_organization resource.
- Now fetches the organization by alias and always sets the ID in Terraform state.
- Fixes issues with outputs and dependencies that require organization_id.

## Related Issue

Fixes #5

## Description

Briefly describe your changes and the motivation behind them. If you made specific design decisions, explain your reasoning.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor/tech debt

## Checklist

- [x] I have tested these changes locally
- [ ] Documentation updated (if needed)
- [ ] Code is linted and formatted
- [ ] All acceptance tests pass
- [ ] I have added/updated tests as needed

## Rollback Plan


## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request?  
- [ ] No
- [ ] Yes (please explain below)

<!-- If yes, explain the changes: -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes, if relevant. -->