### PR TITLE
fix(import): require composite ID for user, group, and domain import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.7] - 2025-07-03
+### Fixed
+- Improved import support for `awsworkmail_user`, `awsworkmail_group`, and `awsworkmail_domain` resources. Import now requires a composite ID in the format `<organization_id>,<resource_id>`, ensuring both required attributes are set in state. This fixes issues with importing resources that require both organization and resource IDs.
+
 ## [0.1.6] - 2025-07-03
 ### Fixed
 - Fixed a bug where the `awsworkmail_organization` resource did not repopulate the `id` attribute in state after a refresh. The Read method now looks up the organization by alias and ensures the ID is always set, improving compatibility with outputs and dependent resources.

--- a/awsworkmail/resource_domain.go
+++ b/awsworkmail/resource_domain.go
@@ -2,6 +2,7 @@ package awsworkmail
 
 import (
 	"context"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 
@@ -61,5 +62,14 @@ func (r *domainResource) Delete(ctx context.Context, req resource.DeleteRequest,
 }
 
 func (r *domainResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+	parts := strings.Split(req.ID, ",")
+	if len(parts) != 2 {
+		resp.Diagnostics.AddError(
+			"Invalid import ID format",
+			"Expected import ID format: <organization_id>,<domain>",
+		)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("organization_id"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), parts[1])...)
 }

--- a/awsworkmail/resource_group.go
+++ b/awsworkmail/resource_group.go
@@ -2,6 +2,7 @@ package awsworkmail
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -271,5 +272,14 @@ func (r *groupResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 }
 
 func (r *groupResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+	parts := strings.Split(req.ID, ",")
+	if len(parts) != 2 {
+		resp.Diagnostics.AddError(
+			"Invalid import ID format",
+			"Expected import ID format: <organization_id>,<group_id>",
+		)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("organization_id"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), parts[1])...)
 }

--- a/awsworkmail/resource_user.go
+++ b/awsworkmail/resource_user.go
@@ -2,6 +2,7 @@ package awsworkmail
 
 import (
 	"context"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -194,5 +195,14 @@ func (r *userResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 }
 
 func (r *userResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+	parts := strings.Split(req.ID, ",")
+	if len(parts) != 2 {
+		resp.Diagnostics.AddError(
+			"Invalid import ID format",
+			"Expected import ID format: <organization_id>,<user_id>",
+		)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("organization_id"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), parts[1])...)
 }


### PR DESCRIPTION
## Related Issue

Fixes #6

## Description

- Updated ImportState for awsworkmail_user, awsworkmail_group, and awsworkmail_domain to require a composite ID in the format <organization_id>,<resource_id>.
- Ensures both organization_id and id are set in state, fixing import issues for resources that require both.
- Improves reliability and user experience for resource import.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor/tech debt

## Checklist

- [ ] I have tested these changes locally
- [ ] Documentation updated (if needed)
- [ ] Code is linted and formatted
- [ ] All acceptance tests pass
- [ ] I have added/updated tests as needed

## Rollback Plan


## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request?  
- [ ] No
- [ ] Yes (please explain below)

<!-- If yes, explain the changes: -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes, if relevant. -->