### PR TITLE
feat(provider): implement region configuration and domain management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+## [0.2.0] - 2025-08-09
+
+### Added
+- Provider-level `region` configuration support for multi-region deployments (#9)
+- Full implementation of `awsworkmail_domain` resource with real AWS WorkMail domain management
+- Automatic MX record generation for registered domains
+- Data source `awsworkmail_user` now uses provider-shared AWS configuration
+
+### Changed
+- **BREAKING**: All resources now use centralized AWS configuration from provider instead of individual configs
+- Provider `region` attribute is optional and maintains backward compatibility with environment variables
+- Domain resource is no longer a stub - now provides full create/read/delete functionality using AWS WorkMail APIs
+
+### Fixed
+- Resolved "Missing Region if not provided by env var" error when AWS_REGION environment variable is not set
+- Fixed domain resource returning no state after creation
+- Eliminated individual AWS config creation in each resource, improving consistency and performance
+
+### Technical Changes
+- All resources (`awsworkmail_organization`, `awsworkmail_user`, `awsworkmail_group`, `awsworkmail_domain`) now implement `Configure` method
+- Centralized AWS configuration sharing between provider and all resources/data sources
+- Added proper error handling for missing provider configuration in resources
+
 ## [0.1.9] - 2025-07-03
 ### Changed
 - Changed the `members` attribute of `awsworkmail_group` from a List to a Set to prevent configuration drift due to member order.

--- a/awsworkmail/resource_domain.go
+++ b/awsworkmail/resource_domain.go
@@ -2,16 +2,28 @@ package awsworkmail
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/workmail"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-type domainResource struct{}
+// domainResourceModel describes the resource data model.
+type domainResourceModel struct {
+	ID             types.String `tfsdk:"id"`
+	OrganizationID types.String `tfsdk:"organization_id"`
+	Domain         types.String `tfsdk:"domain"`
+	MXRecords      types.List   `tfsdk:"mx_records"`
+}
+
+type domainResource struct {
+	cfg aws.Config
+}
 
 func NewDomainResource() resource.Resource {
 	return &domainResource{}
@@ -45,20 +57,155 @@ func (r *domainResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 	}
 }
 
+func (r *domainResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	cfg, ok := req.ProviderData.(aws.Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected aws.Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.cfg = cfg
+}
+
 func (r *domainResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	resp.Diagnostics.AddWarning("Not Implemented", "AWS SDK v2 does not support WorkMail domain registration. This resource is a stub for documentation only.")
+	var data domainResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client := workmail.NewFromConfig(r.cfg)
+
+	// Register the domain with WorkMail
+	input := &workmail.RegisterMailDomainInput{
+		OrganizationId: aws.String(data.OrganizationID.ValueString()),
+		DomainName:     aws.String(data.Domain.ValueString()),
+	}
+
+	_, err := client.RegisterMailDomain(ctx, input)
+	if err != nil {
+		resp.Diagnostics.AddError("Error registering WorkMail domain", err.Error())
+		return
+	}
+
+	data.ID = data.Domain
+
+	getDomainInput := &workmail.GetMailDomainInput{
+		OrganizationId: aws.String(data.OrganizationID.ValueString()),
+		DomainName:     aws.String(data.Domain.ValueString()),
+	}
+
+	domainOutput, err := client.GetMailDomain(ctx, getDomainInput)
+	if err != nil {
+		resp.Diagnostics.AddError("Error retrieving WorkMail domain details", err.Error())
+		return
+	}
+
+	var mxRecords []string
+	for _, record := range domainOutput.Records {
+		if record.Type != nil && *record.Type == "MX" && record.Value != nil {
+			mxRecords = append(mxRecords, *record.Value)
+		}
+	}
+
+	mxRecordsList, diags := types.ListValueFrom(ctx, types.StringType, mxRecords)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	data.MXRecords = mxRecordsList
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *domainResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	resp.Diagnostics.AddWarning("Not Implemented", "AWS SDK v2 does not support WorkMail domain registration. This resource is a stub for documentation only.")
+	var data domainResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client := workmail.NewFromConfig(r.cfg)
+
+	// Get domain information
+	input := &workmail.GetMailDomainInput{
+		OrganizationId: aws.String(data.OrganizationID.ValueString()),
+		DomainName:     aws.String(data.Domain.ValueString()),
+	}
+
+	output, err := client.GetMailDomain(ctx, input)
+	if err != nil {
+		// If domain is not found, remove from state
+		if strings.Contains(err.Error(), "EntityNotFoundException") {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error reading WorkMail domain", err.Error())
+		return
+	}
+
+	// Update MX records
+	var mxRecords []string
+	for _, record := range output.Records {
+		if record.Type != nil && *record.Type == "MX" && record.Value != nil {
+			mxRecords = append(mxRecords, *record.Value)
+		}
+	}
+
+	mxRecordsList, diags := types.ListValueFrom(ctx, types.StringType, mxRecords)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	data.MXRecords = mxRecordsList
+
+	// Save the state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *domainResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	// No-op: not implemented
+	var data domainResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// For domains, updates are mostly read-only operations
+	// The domain name itself cannot be changed, only other attributes
+
+	// Save the updated state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *domainResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	resp.Diagnostics.AddWarning("Not Implemented", "AWS SDK v2 does not support WorkMail domain registration. This resource is a stub for documentation only.")
+	var data domainResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client := workmail.NewFromConfig(r.cfg)
+
+	// Deregister the domain from WorkMail
+	input := &workmail.DeregisterMailDomainInput{
+		OrganizationId: aws.String(data.OrganizationID.ValueString()),
+		DomainName:     aws.String(data.Domain.ValueString()),
+	}
+
+	_, err := client.DeregisterMailDomain(ctx, input)
+	if err != nil {
+		// If domain is already gone, that's fine
+		if !strings.Contains(err.Error(), "EntityNotFoundException") {
+			resp.Diagnostics.AddError("Error deregistering WorkMail domain", err.Error())
+		}
+	}
 }
 
 func (r *domainResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,19 +64,19 @@ To import existing AWS WorkMail resources, you must provide both the Organizatio
 
 - **User:**
   ```
-  terraform import awsworkmail_user.example <organization_id>,<user_id>
+  terraform import awsworkmail_user.example '<organization_id>','<user_id>'
   ```
 - **Group:**
   ```
-  terraform import awsworkmail_group.example <organization_id>,<group_id>
+  terraform import awsworkmail_group.example '<organization_id>','<group_id>'
   ```
 - **Domain:**
   ```
-  terraform import awsworkmail_domain.example <organization_id>,<domain>
+  terraform import awsworkmail_domain.example '<organization_id>','<domain>'
   ```
 - **Organization:**
   ```
-  terraform import awsworkmail_organization.example <organization_id>
+  terraform import awsworkmail_organization.example '<organization_id>'
   ```
 
 See each resource's documentation for details and examples.

--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -30,7 +30,7 @@ output "mx_records" {
 You can import a domain resource by providing both the Organization ID and the domain name, separated by a comma:
 
 ```
-terraform import awsworkmail_domain.example <organization_id>,<domain>
+terraform import awsworkmail_domain.example '<organization_id>','<domain>'
 ```
 
 Example:

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -26,7 +26,7 @@ resource "awsworkmail_group" "example" {
 You can import an existing WorkMail group by providing both the Organization ID and the Group ID, separated by a comma:
 
 ```
-terraform import awsworkmail_group.example <organization_id>,<group_id>
+terraform import awsworkmail_group.example '<organization_id>','<group_id>'
 ```
 
 Example:

--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -23,7 +23,7 @@ resource "awsworkmail_organization" "example" {
 You can import an existing WorkMail organization by its AWS OrganizationId:
 
 ```
-terraform import awsworkmail_organization.example <organization_id>
+terraform import awsworkmail_organization.example '<organization_id>'
 ```
 
 Example:

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -29,7 +29,7 @@ resource "awsworkmail_user" "example" {
 You can import an existing WorkMail user by providing both the Organization ID and the User ID, separated by a comma:
 
 ```
-terraform import awsworkmail_user.example <organization_id>,<user_id>
+terraform import awsworkmail_user.example '<organization_id>','<user_id>'
 ```
 
 Example:


### PR DESCRIPTION
## Related Issue

Resolves #9 - "Missing Region if not provided by env var"

## Description

BREAKING CHANGES:
* All resources now use centralized AWS configuration from provider
* Domain resource converted from stub to full implementation

Features:
* Add optional region attribute to provider schema for multi-region support
* Implement real WorkMail domain management with RegisterMailDomain API
* Add automatic MX record generation for registered domains
* Centralize AWS config sharing across all resources and data sources

Fixes:
* Resolve "Missing Region if not provided by env var" error (#9)
* Fix domain resource returning no state after creation
* Eliminate duplicate AWS client creation across resources


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactor/tech debt

## Checklist

- [x] I have tested these changes locally
- [x] Documentation updated (if needed)
- [x] Code is linted and formatted
- [x] All acceptance tests pass
- [x] I have added/updated tests as needed

## Rollback Plan

<!-- Describe how to revert this change if needed, or confirm that a rollback is straightforward. -->

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request?  
- [x] No
- [ ] Yes (please explain below)

<!-- If yes, explain the changes: -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes, if relevant. -->