### PR TITLE
Adding support for AWS profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-18
+
+### Added
+- Provider-level `profile` configuration support for shared AWS credentials files
+
+### Enhanced
+- AWS SDK configuration logic to support dynamic option injection (Region and Profile)
+
 ## [0.3.0] - 2025-09-28
 
 ### Added

--- a/awsworkmail/provider.go
+++ b/awsworkmail/provider.go
@@ -35,6 +35,7 @@ type AwsWorkMailProviderModel struct {
 	Endpoint   types.String `tfsdk:"endpoint"`
 	Region     types.String `tfsdk:"region"`
 	AssumeRole types.Object `tfsdk:"assume_role"`
+	Profile    types.String `tfsdk:"profile"`
 }
 
 // AssumeRoleModel describes the assume_role configuration.
@@ -59,6 +60,10 @@ func (p *AwsWorkMailProvider) Schema(ctx context.Context, req provider.SchemaReq
 			},
 			"region": pschema.StringAttribute{
 				MarkdownDescription: "AWS region for WorkMail operations. If not specified, uses the standard AWS SDK configuration (environment variables, ~/.aws/config, etc.). WorkMail is only available in select regions.",
+				Optional:            true,
+			},
+			"profile": pschema.StringAttribute{
+				MarkdownDescription: "AWS profile used for connecting to AWS",
 				Optional:            true,
 			},
 			"assume_role": pschema.SingleNestedAttribute{
@@ -96,14 +101,18 @@ func (p *AwsWorkMailProvider) Configure(ctx context.Context, req provider.Config
 		return
 	}
 
-	// Create initial AWS config with optional region override
+	var profileOpts []func(*config.LoadOptions) error
+	if !data.Profile.IsNull() && data.Profile.ValueString() != "" {
+		profileOpts = append(profileOpts, config.WithSharedConfigProfile(data.Profile.ValueString()))
+	}
+
 	var cfg aws.Config
 	var err error
 
 	if !data.Region.IsNull() && data.Region.ValueString() != "" {
-		cfg, err = config.LoadDefaultConfig(ctx, config.WithRegion(data.Region.ValueString()))
+		cfg, err = config.LoadDefaultConfig(ctx, append(profileOpts, config.WithRegion(data.Region.ValueString()))...)
 	} else {
-		cfg, err = config.LoadDefaultConfig(ctx)
+		cfg, err = config.LoadDefaultConfig(ctx, profileOpts...)
 	}
 
 	if err != nil {

--- a/awsworkmail/provider.go
+++ b/awsworkmail/provider.go
@@ -101,11 +101,13 @@ func (p *AwsWorkMailProvider) Configure(ctx context.Context, req provider.Config
 		return
 	}
 
+	// Handle profile if configured
 	var profileOpts []func(*config.LoadOptions) error
 	if !data.Profile.IsNull() && data.Profile.ValueString() != "" {
 		profileOpts = append(profileOpts, config.WithSharedConfigProfile(data.Profile.ValueString()))
 	}
 
+	// Create initial AWS config with optional region override
 	var cfg aws.Config
 	var err error
 


### PR DESCRIPTION
## Related Issue

Fixes #137 

## Description

This PR adds support for the profile attribute in the provider configuration. This allows users to specify a named profile from their shared AWS credentials/config files. I've also refactored the SDK initialization to use functional options, ensuring the provider remains flexible for future configuration parameters.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor/tech debt

## Checklist

- [x] I have tested these changes locally
- [x] Documentation updated (if needed)
- [x] Code is linted and formatted
- [x] All acceptance tests pass
- [x] I have added/updated tests as needed

## Rollback Plan

<!-- Describe how to revert this change if needed, or confirm that a rollback is straightforward. -->

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request?  
- [x] No
- [ ] Yes (please explain below)

<!-- If yes, explain the changes: -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes, if relevant. -->